### PR TITLE
feat(org-members): scaffold OrganizationMembers module to manage user roles within organizations

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,10 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { OrganizationsModule } from './organizations/organizations.module';
+import { OrganizationMembersModule } from './organization-members/organization-members.module';
 
 @Module({
-  imports: [AuthModule, OrganizationsModule],
+  imports: [AuthModule, OrganizationsModule, OrganizationMembersModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/organization-members/dto/create-organization-member.dto.ts
+++ b/src/organization-members/dto/create-organization-member.dto.ts
@@ -1,0 +1,1 @@
+export class CreateOrganizationMemberDto {}

--- a/src/organization-members/dto/update-organization-member.dto.ts
+++ b/src/organization-members/dto/update-organization-member.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateOrganizationMemberDto } from './create-organization-member.dto';
+
+export class UpdateOrganizationMemberDto extends PartialType(CreateOrganizationMemberDto) {}

--- a/src/organization-members/entities/organization-member.entity.ts
+++ b/src/organization-members/entities/organization-member.entity.ts
@@ -1,0 +1,1 @@
+export class OrganizationMember {}

--- a/src/organization-members/organization-members.controller.spec.ts
+++ b/src/organization-members/organization-members.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrganizationMembersController } from './organization-members.controller';
+import { OrganizationMembersService } from './organization-members.service';
+
+describe('OrganizationMembersController', () => {
+  let controller: OrganizationMembersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OrganizationMembersController],
+      providers: [OrganizationMembersService],
+    }).compile();
+
+    controller = module.get<OrganizationMembersController>(OrganizationMembersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/organization-members/organization-members.controller.ts
+++ b/src/organization-members/organization-members.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { OrganizationMembersService } from './organization-members.service';
+import { CreateOrganizationMemberDto } from './dto/create-organization-member.dto';
+import { UpdateOrganizationMemberDto } from './dto/update-organization-member.dto';
+
+@Controller('organization-members')
+export class OrganizationMembersController {
+  constructor(private readonly organizationMembersService: OrganizationMembersService) {}
+
+  @Post()
+  create(@Body() createOrganizationMemberDto: CreateOrganizationMemberDto) {
+    return this.organizationMembersService.create(createOrganizationMemberDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.organizationMembersService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.organizationMembersService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateOrganizationMemberDto: UpdateOrganizationMemberDto) {
+    return this.organizationMembersService.update(+id, updateOrganizationMemberDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.organizationMembersService.remove(+id);
+  }
+}

--- a/src/organization-members/organization-members.module.ts
+++ b/src/organization-members/organization-members.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { OrganizationMembersService } from './organization-members.service';
+import { OrganizationMembersController } from './organization-members.controller';
+
+@Module({
+  controllers: [OrganizationMembersController],
+  providers: [OrganizationMembersService],
+})
+export class OrganizationMembersModule {}

--- a/src/organization-members/organization-members.service.spec.ts
+++ b/src/organization-members/organization-members.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrganizationMembersService } from './organization-members.service';
+
+describe('OrganizationMembersService', () => {
+  let service: OrganizationMembersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OrganizationMembersService],
+    }).compile();
+
+    service = module.get<OrganizationMembersService>(OrganizationMembersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/organization-members/organization-members.service.ts
+++ b/src/organization-members/organization-members.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateOrganizationMemberDto } from './dto/create-organization-member.dto';
+import { UpdateOrganizationMemberDto } from './dto/update-organization-member.dto';
+
+@Injectable()
+export class OrganizationMembersService {
+  create(createOrganizationMemberDto: CreateOrganizationMemberDto) {
+    return 'This action adds a new organizationMember';
+  }
+
+  findAll() {
+    return `This action returns all organizationMembers`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} organizationMember`;
+  }
+
+  update(id: number, updateOrganizationMemberDto: UpdateOrganizationMemberDto) {
+    return `This action updates a #${id} organizationMember`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} organizationMember`;
+  }
+}


### PR DESCRIPTION
- Generated OrganizationMembers resource using NestJS CLI with REST transport and CRUD entry points
- Includes controller, service, DTOs, and entity for managing user membership within organizations
- Lays the groundwork for implementing multi-tenant role-based access control (RBAC)
- Will support operations like inviting users, assigning roles, and removing members